### PR TITLE
chore: remove elasticsearch service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,41 +1,8 @@
 services:
-  index:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
-    expose:
-      - "9200"
-    ports:
-      - "127.0.0.1:9200:9200"
-    container_name: index
-    environment:
-      - node.name=index
-      - cluster.name=opensanctions-index
-      - discovery.type=single-node
-      - bootstrap.memory_lock=true
-      - xpack.security.enabled=false
-      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
-    ##ulimits:
-      ##memlock:
-        ##soft: -1
-        ##hard: -1
-    volumes:
-      - index-os-data:/usr/share/elasticsearch/data
-    deploy:
-      placement:
-        max_replicas_per_node: 1
-      restart_policy:
-        condition: on-failure
-
   app:
     image: ghcr.io/opensanctions/yente:4.1.0
-    depends_on:
-      - index
     ports:
       - "127.0.0.1:8000:8000"
-    environment:
-      YENTE_INDEX_TYPE: "elasticsearch"
-      YENTE_INDEX_URL: http://index:9200
-      # Set this to a randomly generated string to enable the /updatez API:
-      YENTE_UPDATE_TOKEN: ""
     # If you want to index data from the host machine as a custom dataset,
     # create a volume mount here to make that data accessible from the 
     # container:


### PR DESCRIPTION
## Updates
* this service is no longer needed, as aml-cdk provisions a fargate instance with elasticsearch by default